### PR TITLE
fix Class name convention error

### DIFF
--- a/app/src/main/java/com/socialcoding/cctv/MainActivity.java
+++ b/app/src/main/java/com/socialcoding/cctv/MainActivity.java
@@ -56,7 +56,7 @@ public class MainActivity extends AppCompatActivity
     private DrawerLayout drawer;
 
     private AutoCompleteTextView searchAutoCompleteTextView;
-    private PlaceAutocompleteAdapter placeAutocompleteAdapter;
+    private PlaceAutoCompleteAdapter placeAutocompleteAdapter;
     private static final LatLngBounds BOUNDS_KOREA = new LatLngBounds(
             new LatLng(37.4784514, 126.8818163), new LatLng(37.5562989, 126.9220863));
 
@@ -458,7 +458,7 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     public void onConnected(Bundle bundle) {
-        placeAutocompleteAdapter = new PlaceAutocompleteAdapter(this, client, BOUNDS_KOREA, null);
+        placeAutocompleteAdapter = new PlaceAutoCompleteAdapter(this, client, BOUNDS_KOREA, null);
         searchAutoCompleteTextView.setAdapter(placeAutocompleteAdapter);
     }
 

--- a/app/src/main/java/com/socialcoding/cctv/PlaceAutoCompleteAdapter.java
+++ b/app/src/main/java/com/socialcoding/cctv/PlaceAutoCompleteAdapter.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
  * The API client must be maintained in the encapsulating Activity, including all lifecycle and
  * connection states. The API client must be connected with the {@link Places#GEO_DATA_API} API.
  */
-public class PlaceAutocompleteAdapter
+public class PlaceAutoCompleteAdapter
         extends ArrayAdapter<AutocompletePrediction> implements Filterable {
 
     private static final String TAG = "PlaceAutocompleteAdapter";
@@ -80,7 +80,7 @@ public class PlaceAutocompleteAdapter
      *
      * @see android.widget.ArrayAdapter#ArrayAdapter(android.content.Context, int)
      */
-    public PlaceAutocompleteAdapter(Context context, GoogleApiClient googleApiClient,
+    public PlaceAutoCompleteAdapter(Context context, GoogleApiClient googleApiClient,
                                     LatLngBounds bounds, AutocompleteFilter filter) {
         super(context, android.R.layout.simple_expandable_list_item_2, android.R.id.text1);
         mGoogleApiClient = googleApiClient;


### PR DESCRIPTION
PlaceAutoCompleteAdapter 항목의

클래스 이름과 파일 이름 내부 참조 이름이

PlaceAutoCompleteAdapter != PlaceAutocompleteAdapter

으로 상이하여 빌드 안됨.